### PR TITLE
[Urgent] Fix storage save exception

### DIFF
--- a/src/main/java/seedu/taskell/MainApp.java
+++ b/src/main/java/seedu/taskell/MainApp.java
@@ -53,6 +53,7 @@ public class MainApp extends Application {
         super.init();
 
         config = initConfig(getApplicationParameter("config"));
+        
         storage = new StorageManager(config.getTaskManagerFilePath(), config.getUserPrefsFilePath());
 
         userPrefs = initPrefs(config);
@@ -206,8 +207,11 @@ public class MainApp extends Application {
     /** @@author A0142130A **/
     @Subscribe
     private void handleStorageLocationChangedEvent(StorageLocationChangedEvent event) {
+        logger.info("saving storage");
         config = event.getConfig();
+        storage.clearTaskManager();
         storage = new StorageManager(config.getTaskManagerFilePath(), config.getUserPrefsFilePath());
+        SaveStorageLocationCommand.setStorage(storage);
     }
     /** @@author **/
 

--- a/src/main/java/seedu/taskell/logic/commands/SaveStorageLocationCommand.java
+++ b/src/main/java/seedu/taskell/logic/commands/SaveStorageLocationCommand.java
@@ -8,7 +8,9 @@ import seedu.taskell.commons.core.Config;
 import seedu.taskell.commons.core.EventsCenter;
 import seedu.taskell.commons.core.LogsCenter;
 import seedu.taskell.commons.events.storage.StorageLocationChangedEvent;
+import seedu.taskell.commons.exceptions.DataConversionException;
 import seedu.taskell.model.ReadOnlyTaskManager;
+import seedu.taskell.model.task.Task;
 import seedu.taskell.storage.JsonConfigStorage;
 import seedu.taskell.storage.Storage;
 
@@ -63,7 +65,11 @@ public class SaveStorageLocationCommand extends Command {
         indicateStorageLocationChanged();
         try {
             storage.saveTaskManager(taskManager, newStorageFilePath);
+            storage.readTaskManager();
         } catch (IOException e) {
+            handleInvalidFilePathException();
+            return new CommandResult(MESSAGE_INVALID_PATH);
+        } catch (DataConversionException e) {
             handleInvalidFilePathException();
             return new CommandResult(MESSAGE_INVALID_PATH);
         }

--- a/src/main/java/seedu/taskell/logic/parser/Parser.java
+++ b/src/main/java/seedu/taskell/logic/parser/Parser.java
@@ -70,7 +70,7 @@ public class Parser {
     private boolean hasChangedEndTime = false;
     private boolean hasChangedPriority = false;
 
-    private static History history;
+    private History history;
 
     public Parser() {
         history = HistoryManager.getInstance();

--- a/src/main/java/seedu/taskell/storage/Storage.java
+++ b/src/main/java/seedu/taskell/storage/Storage.java
@@ -29,6 +29,8 @@ public interface Storage extends TaskManagerStorage, UserPrefsStorage {
 
     @Override
     void saveTaskManager(ReadOnlyTaskManager taskManager) throws IOException;
+    
+    void clearTaskManager();
 
     /**
      * Saves the current version of the Task Manager to the hard disk.

--- a/src/main/java/seedu/taskell/storage/StorageManager.java
+++ b/src/main/java/seedu/taskell/storage/StorageManager.java
@@ -68,6 +68,7 @@ public class StorageManager extends ComponentManager implements Storage {
     @Override
     public void saveTaskManager(ReadOnlyTaskManager taskManager) throws IOException {
         saveTaskManager(taskManager, taskManagerStorage.getTaskManagerFilePath());
+        logger.info(taskManagerStorage.getTaskManagerFilePath());
     }
 
     @Override
@@ -75,7 +76,14 @@ public class StorageManager extends ComponentManager implements Storage {
         logger.fine("Attempting to write to data file: " + filePath);
         taskManagerStorage.saveTaskManager(taskManager, filePath);
     }
-
+    
+    @Override
+    /** fixes bug whereby Taskell saves new data to both new and old file locations
+     *  in the same session (meaning user has not closed app)
+     * */
+    public void clearTaskManager() {
+        this.taskManagerStorage = null;
+    }
 
     @Override
     @Subscribe

--- a/src/test/java/guitests/SaveStorageLocationCommandTest.java
+++ b/src/test/java/guitests/SaveStorageLocationCommandTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.junit.After;
 import org.junit.Test;
 
 import seedu.taskell.TestApp;
@@ -40,13 +41,11 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assertWriteToXmlSuccess();
     }
     
-    /** @@author A0142130A-unused **/
-    //This test is not run because it has assertion error on Travis build
-    //@Test
+    @Test
     public void saveToInvalidFilePath() throws DataConversionException {
         JsonConfigStorage jsonConfigStorage = new JsonConfigStorage(CONFIG_LOCATION);
 
-        commandBox.runCommand("save E:");   
+        commandBox.runCommand("save >>>");   
         
         Optional<Config> newConfig = jsonConfigStorage.readConfig(CONFIG_JSON);
         String newFilePath = newConfig.get().getTaskManagerFilePath();
@@ -55,13 +54,11 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assert(newFilePath.equals(DEFAULT_SAVE_LOCATION));
     }
     
-    /** @@author A0142130A **/
-    
     /** NOTE: because of the way SaveStorageLocationCommand works, after running this command
      *          config.json in Taskell saves the test data so this method is necessary to reset
      *          config.json to default data
      * */
-    @Test
+    @After
     public void resetConfigFile() throws IOException {
         Config config = new Config();
         config.setAppTitle("Taskell");

--- a/src/test/java/guitests/SaveStorageLocationCommandTest.java
+++ b/src/test/java/guitests/SaveStorageLocationCommandTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.junit.After;
 import org.junit.Test;
 
 import seedu.taskell.TestApp;
@@ -61,7 +62,7 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
      *          config.json in Taskell saves the test data so this method is necessary to reset
      *          config.json to default data
      * */
-    @Test
+    @After
     public void resetConfigFile() throws IOException {
         Config config = new Config();
         config.setAppTitle("Taskell");

--- a/src/test/java/guitests/SaveStorageLocationCommandTest.java
+++ b/src/test/java/guitests/SaveStorageLocationCommandTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.junit.After;
 import org.junit.Test;
 
 import seedu.taskell.TestApp;
@@ -41,11 +40,13 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assertWriteToXmlSuccess();
     }
     
-    @Test
+    /** @@author A0142130A-unused **/
+    //This test is not run because it has assertion error on Travis build
+    //@Test
     public void saveToInvalidFilePath() throws DataConversionException {
         JsonConfigStorage jsonConfigStorage = new JsonConfigStorage(CONFIG_LOCATION);
 
-        commandBox.runCommand("save >>>");   
+        commandBox.runCommand("save E:");   
         
         Optional<Config> newConfig = jsonConfigStorage.readConfig(CONFIG_JSON);
         String newFilePath = newConfig.get().getTaskManagerFilePath();
@@ -54,11 +55,13 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assert(newFilePath.equals(DEFAULT_SAVE_LOCATION));
     }
     
+    /** @@author A0142130A **/
+    
     /** NOTE: because of the way SaveStorageLocationCommand works, after running this command
      *          config.json in Taskell saves the test data so this method is necessary to reset
      *          config.json to default data
      * */
-    @After
+    @Test
     public void resetConfigFile() throws IOException {
         Config config = new Config();
         config.setAppTitle("Taskell");

--- a/src/test/java/guitests/SaveStorageLocationCommandTest.java
+++ b/src/test/java/guitests/SaveStorageLocationCommandTest.java
@@ -40,13 +40,11 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assertWriteToXmlSuccess();
     }
     
-    /** @@author A0142130A-unused **/
-    //This test is not run because it has assertion error on Travis build
-    //@Test
-    public void saveToInvalidFilePath() throws DataConversionException {
+    @Test
+    public void saveToInvalidFilePath_fail() throws DataConversionException {
         JsonConfigStorage jsonConfigStorage = new JsonConfigStorage(CONFIG_LOCATION);
 
-        commandBox.runCommand("save E:");   
+        commandBox.runCommand("save ****");   
         
         Optional<Config> newConfig = jsonConfigStorage.readConfig(CONFIG_JSON);
         String newFilePath = newConfig.get().getTaskManagerFilePath();
@@ -54,8 +52,6 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         
         assert(newFilePath.equals(DEFAULT_SAVE_LOCATION));
     }
-    
-    /** @@author A0142130A **/
     
     /** NOTE: because of the way SaveStorageLocationCommand works, after running this command
      *          config.json in Taskell saves the test data so this method is necessary to reset

--- a/src/test/java/guitests/SaveStorageLocationCommandTest.java
+++ b/src/test/java/guitests/SaveStorageLocationCommandTest.java
@@ -40,11 +40,13 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         assertWriteToXmlSuccess();
     }
     
-    @Test
-    public void saveToInvalidFilePath_fail() throws DataConversionException {
+    /** @@author A0142130A-unused **/
+    //This test is not run because it has assertion error on Travis build
+    //@Test
+    public void saveToInvalidFilePath() throws DataConversionException {
         JsonConfigStorage jsonConfigStorage = new JsonConfigStorage(CONFIG_LOCATION);
 
-        commandBox.runCommand("save ****");   
+        commandBox.runCommand("save E:");   
         
         Optional<Config> newConfig = jsonConfigStorage.readConfig(CONFIG_JSON);
         String newFilePath = newConfig.get().getTaskManagerFilePath();
@@ -52,6 +54,8 @@ public class SaveStorageLocationCommandTest extends TaskManagerGuiTest {
         
         assert(newFilePath.equals(DEFAULT_SAVE_LOCATION));
     }
+    
+    /** @@author A0142130A **/
     
     /** NOTE: because of the way SaveStorageLocationCommand works, after running this command
      *          config.json in Taskell saves the test data so this method is necessary to reset


### PR DESCRIPTION
found that save sometimes saves filepaths that are valid but cannot be read from file (for some unknown reason), have written code to reject such filepaths

please test thoroughly

update: pulled the wrong information about symbols not allowed for file naming, this is the correct one
![image](https://cloud.githubusercontent.com/assets/13817632/19954031/31017f74-a1af-11e6-89aa-6838e877d8c2.png)