### PR TITLE
Implement substring search in find

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -114,7 +114,7 @@ Diagram 2: Displays all the tasks to be done by today after typing list-date.
 <!--- @@author A0142130A --->  
 
 #### Finding tasks: `find`
-You can use the find command to view tasks with specific keywords.<br>
+You can use the find command to view tasks with specific keywords. Tasks with words that match the keyword include those that contain the keyword, for example, searching for "book" will match with "book", "textbook", "storybook" etc. You can also search with multiple keywords at the same time.<br>
 Formats: <br>
 -`find KEYWORD [MORE_KEYWORDS]`<br>
 Displays a list of tasks with description or tags that match all the keywords.<br>
@@ -122,7 +122,7 @@ Example: `find banana milk essay`<br>
 This returns all tasks with description or tags that match all keywords `banana`, `milk`, and `essay`. <br>
 
 -`find-tag TAG [MORE_TAGS]`<br>
-Displays list of tasks with the same tags.<br>
+Displays list of tasks with the same tags. Use this if you want to only search by tags and not description.<br>
 Example: `find homework essay cs2103`<br>
 This returns any task with either tag `homework`, `essay`, or `cs2103`.<br>
  <br><p align="center"><img src="images/findReport.png" width="800"></br>

--- a/src/main/java/seedu/taskell/MainApp.java
+++ b/src/main/java/seedu/taskell/MainApp.java
@@ -208,7 +208,7 @@ public class MainApp extends Application {
     /** @@author A0142130A **/
     @Subscribe
     private void handleStorageLocationChangedEvent(StorageLocationChangedEvent event) {
-        logger.info("saving storage");
+        logger.info("saving new filepath to storage");
         config = event.getConfig();
         storage.clearTaskManager();
         storage = new StorageManager(config.getTaskManagerFilePath(), config.getUserPrefsFilePath());

--- a/src/main/java/seedu/taskell/commons/util/StringUtil.java
+++ b/src/main/java/seedu/taskell/commons/util/StringUtil.java
@@ -14,6 +14,16 @@ public class StringUtil {
         List<String> strings = Arrays.asList(split);
         return strings.stream().filter(s -> s.equals(query.toLowerCase())).count() > 0;
     }
+    
+    /** @@author A0142130A **/
+    /** checks if source contains query as substring and ignores case
+     */
+    public static boolean containsSubstringAndIgnoreCase(String source, String query) {
+        String[] split = source.toLowerCase().split("\\s+");
+        List<String> strings = Arrays.asList(split);
+        return strings.stream().filter(s -> s.contains(query.toLowerCase())).count() > 0;
+    }
+    /** @@author **/
 
     /**
      * Returns a detailed message of the t, including the stack trace.

--- a/src/main/java/seedu/taskell/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/taskell/logic/commands/FindCommand.java
@@ -24,7 +24,7 @@ public class FindCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        model.updateFilteredTaskList(keywords);
+        model.updateFilteredTaskListByAllKeywords(keywords);
         return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
     }
 

--- a/src/main/java/seedu/taskell/model/Model.java
+++ b/src/main/java/seedu/taskell/model/Model.java
@@ -38,7 +38,7 @@ public interface Model {
     void updateFilteredTaskListPriority(Set<String> keywords);
     
     /** Updates the filter of the filtered task list to filter by the given keywords (AND operation)*/
-    void updateFilteredTaskList(Set<String> keywords);
+    void updateFilteredTaskListByAllKeywords(Set<String> keywords);
     
     /** Updates the filter of the filtered task list to filter by the given date*/
     void updateFilteredtaskListDate(Set<String> keywords);

--- a/src/main/java/seedu/taskell/model/ModelManager.java
+++ b/src/main/java/seedu/taskell/model/ModelManager.java
@@ -86,6 +86,8 @@ public class ModelManager extends ComponentManager implements Model {
         indicateTaskManagerChanged();
     }
 
+    /** @@author A0142130A **/
+    
     @Override
     public boolean isTaskPresent(Task task) {
     	if (task == null) {
@@ -94,6 +96,8 @@ public class ModelManager extends ComponentManager implements Model {
     	}
         return taskManager.isTaskPresent(task);
     }
+    
+    /** @@author **/
 
     // =========== Filtered Task List Accessors
     // ===============================================================
@@ -109,7 +113,7 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public void updateFilteredTaskList(Set<String> keywords) {
+    public void updateFilteredTaskListByAllKeywords(Set<String> keywords) {
         updateFilteredTaskList(new PredicateExpression(new DescriptionAndTagsQualifier(keywords)));
     }
 
@@ -186,7 +190,7 @@ public class ModelManager extends ComponentManager implements Model {
         @Override
         public boolean run(ReadOnlyTask task) {
             String searchString = task.getDescription().description + " " + task.tagsSimpleString();
-            return nameKeyWords.stream().allMatch(keyword -> StringUtil.containsIgnoreCase(searchString, keyword));
+            return nameKeyWords.stream().allMatch(keyword -> StringUtil.containsSubstringAndIgnoreCase(searchString, keyword));
         }
 
         /** @@author **/
@@ -208,7 +212,8 @@ public class ModelManager extends ComponentManager implements Model {
         @Override
         public boolean run(ReadOnlyTask task) {
             return tagsKeyWords.stream()
-                    .filter(keyword -> StringUtil.containsIgnoreCase(task.tagsSimpleString(), keyword)).findAny()
+                    .filter(keyword -> StringUtil.containsSubstringAndIgnoreCase(task.tagsSimpleString(), keyword))
+                    .findAny()
                     .isPresent();
         }
 

--- a/src/main/java/seedu/taskell/model/TaskManager.java
+++ b/src/main/java/seedu/taskell/model/TaskManager.java
@@ -180,7 +180,9 @@ public class TaskManager implements ReadOnlyTaskManager {
         return Objects.hash(tasks, tags);
     }
     
+    /** @@author A0142130A **/
     public boolean isTaskPresent(Task task) {
         return tasks.contains(task);
     }
+    /** @@author **/
 }

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -36,6 +36,11 @@ public class FindCommandTest extends TaskManagerGuiTest {
         assertFindResult("find friends owesMoney", td.borrowBooks);
     }
     
+    @Test
+    public void find_bySubstringKeyword_success() {
+        assertFindResult("find fri", td.archivePastEmails, td.borrowBooks);
+    }
+    
     /** @@author **/
 
     @Test

--- a/src/test/java/guitests/FindTagCommandTest.java
+++ b/src/test/java/guitests/FindTagCommandTest.java
@@ -35,6 +35,11 @@ public class FindTagCommandTest extends TaskManagerGuiTest {
         commandBox.runCommand("find-tagfriends");
         assertResultMessage(Messages.MESSAGE_UNKNOWN_COMMAND);
     }
+    
+    @Test
+    public void find_bySubstringKeyword_success() {
+        assertFindResult("find MonEY", td.borrowBooks, td.collectParcel);
+    }
 
     private void assertFindResult(String command, TestTask... expectedHits ) {
         commandBox.runCommand(command);

--- a/src/test/java/seedu/taskell/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/taskell/commons/util/StringUtilTest.java
@@ -39,16 +39,28 @@ public class StringUtilTest {
     }
 
     @Test
-    public void getDetails_exceptionGiven(){
+    public void getDetails_exceptionGiven() {
         assertThat(StringUtil.getDetails(new FileNotFoundException("file not found")),
                    containsString("java.io.FileNotFoundException: file not found"));
     }
 
     @Test
-    public void getDetails_nullGiven_assertionError(){
+    public void getDetails_nullGiven_assertionError() {
         thrown.expect(AssertionError.class);
         StringUtil.getDetails(null);
     }
 
+    /** @@author A0142130A **/
+    @Test
+    public void containsSubstringAndIgnoreCase_true() {
+        boolean result = StringUtil.containsSubstringAndIgnoreCase("butterfly", "butter");
+        assertTrue(result);
+    }
 
+    @Test
+    public void containsSubstringAndIgnoreCase_false() {
+        boolean result = StringUtil.containsSubstringAndIgnoreCase("chicken", "butter");
+        assertFalse(result);
+    }
+    /** @@author **/
 }

--- a/src/test/java/seedu/taskell/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/taskell/logic/LogicManagerTest.java
@@ -614,16 +614,16 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void execute_find_onlyMatchesFullWordsInNames() throws Exception {
+    public void execute_find_matchesKeywordsInNames() throws Exception {
         TestDataHelper helper = new TestDataHelper();
         Task pTarget1 = helper.generateTaskWithName("bla bla KEY bla");
         Task pTarget2 = helper.generateTaskWithName("bla KEY bla bceofeia");
+        Task pTarget3 = helper.generateTaskWithName("KEYKEYKEY sduauo");
         Task p1 = helper.generateTaskWithName("KE Y");
-        Task p2 = helper.generateTaskWithName("KEYKEYKEY sduauo");
 
-        List<Task> fourTasks = helper.generateTaskList(p1, pTarget1, p2, pTarget2);
+        List<Task> fourTasks = helper.generateTaskList(p1, pTarget1, pTarget2, pTarget3);
         TaskManager expectedAB = helper.generateTaskManager(fourTasks);
-        List<Task> expectedList = helper.generateTaskList(pTarget1, pTarget2);
+        List<Task> expectedList = helper.generateTaskList(pTarget1, pTarget2, pTarget3);
         helper.addToModel(model, fourTasks);
 
         assertCommandBehavior("find KEY", Command.getMessageForTaskListShownSummary(expectedList.size()), expectedAB,


### PR DESCRIPTION
this closes #226 
find and find-tag commands now support substring search, meaning "find butter" can return "butterfly" and "find chick" can return "chicken"

@CS2103AUG2016-W15-C3/testing 
@CS2103AUG2016-W15-C3/documentation 
@CS2103AUG2016-W15-C3/code-quality 